### PR TITLE
[fix]: fixes bug related to instance re-initialization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,8 @@ function firebaseAuthScheme(server, options) {
             }),
             databaseURL: options.credential.databaseURL
           })
+
+          options.instance = firebaseInstance
         }
 
         // Check if Firebase is initialized


### PR DESCRIPTION
Fixes a bug where the `options.instance` initialization never happens & therefore fails on a reinitialization error for subsequent requests.

`FirebaseAppError: The default Firebase app already exists. This means you called initializeApp() more than once without providing an app name as the second argument. In most cases you only need to call initializeApp() once. But if you do want to initialize multiple apps, pass a second argument to initializeApp() to give each app a unique name.`